### PR TITLE
Increase Lambda execution time to account for my growing list of artists.

### DIFF
--- a/cdk/stacks/custom_constructs/notifier.py
+++ b/cdk/stacks/custom_constructs/notifier.py
@@ -14,7 +14,8 @@ from aws_cdk import (
     aws_stepfunctions_tasks as task,
     aws_sns as sns,
     aws_secretsmanager as ssm,
-    aws_iam as iam
+    aws_iam as iam,
+    Duration
 )
 
 class NotifierConstruct(Construct):
@@ -58,6 +59,7 @@ class NotifierConstruct(Construct):
             description='Fetches the latest music released by any of the artists being monitored',
             function_name='GetLatestMusicForNotifierHandler',
             runtime=lambda_.Runtime.PYTHON_3_10,
+            timeout=Duration.seconds(15),
             code=lambda_.Code.from_asset('lambda_functions/NotifierConstructLambdas'),
             handler='get_latest_music_for_notifier.handler',
             layers=[requests_layer],


### PR DESCRIPTION
## Summary 
This pull request fixes an issue where the Lambda responsible for fetching the latest music for each artist would timeout due to the growing size of artists on the list. 

## Changes
1. Increased Lambda execution time before timeout from 3 seconds to 15 seconds