### PR TITLE
Fix `KeyError` Issue in `MessageNewMusicHandler` Lambda

### DIFF
--- a/cdk/lambda_functions/NotifierConstructLambdas/message_new_music.py
+++ b/cdk/lambda_functions/NotifierConstructLambdas/message_new_music.py
@@ -67,9 +67,9 @@ def send_email_with_new_music(event: list) -> None:
     # Format new music into a string
     email_list_of_strings: list[str] = []
     for index, artist in enumerate(event, start=1):
-        if artist["last_album_details"]['last_album_name']:
+        if artist.get('last_album_details'):
             email_list_of_strings.append(f'{index}. \n\t{artist["artist_name"]} dropped "{artist["last_album_details"]["last_album_name"]}" on {artist["last_album_details"]["last_album_release_date"]}.')
-        elif artist["last_single_details"]['last_single_name']:
+        elif artist.get('last_single_details'):
             email_list_of_strings.append(f'{index}. \n\t{artist["artist_name"]} dropped "{artist["last_single_details"]["last_single_name"]}" on {artist["last_single_details"]["last_single_release_date"]}.')
         
     # Join all strings together to create one long string for the email


### PR DESCRIPTION
## Summary: 
This pull request addresses a `KeyError` that was occurring when parsing the list of new music in the `MessageNewMusicHandler` lambda. This error occurred when we attempted to access non-existent keys in the `artist` dictionary.

## Changes:
1. Replaced dictionary key access with the `get` method:
   - Instead of directly accessing dictionary keys which could lead to a `KeyError` if the key doesn't exist, I am now using the dictionary's `get` method. This method returns the value for a key if it exists, and `None` if it doesn't, thus avoiding the `KeyError`.
