### PR TITLE
Update Removal Policy for Artist DynamoDB Table to `RETAIN`

### DIFF
--- a/cdk/stacks/database_stack.py
+++ b/cdk/stacks/database_stack.py
@@ -24,7 +24,7 @@ class DatabaseStack(Stack):
             },
             stream=ddb.StreamViewType.NEW_IMAGE,  # Enable stream for lambda invocations
             encryption=ddb.TableEncryption.AWS_MANAGED,
-            removal_policy=RemovalPolicy.DESTROY
+            removal_policy=RemovalPolicy.RETAIN
         )
 
 


### PR DESCRIPTION
## Summary

As our application has moved to full production with a sizable amount of data in the artist table, we need to ensure the preservation of the data during any stack updates. This PR updates the removal policy for the DynamoDB table from `DESTROY` to `RETAIN`.