### PR TITLE
Refactor Terminal Styling: Rename Colors Class and Remove Helper Functions

### DIFF
--- a/cli/actions/actions.py
+++ b/cli/actions/actions.py
@@ -6,7 +6,7 @@ from exceptions.error_handling import (
     FailedToAddArtistToTable,
     FailedToRemoveArtistFromTable
 )
-from ui.colors import Colors, print_colors, colorfy
+from ui.colors import Style
 from botocore.exceptions import ClientError
 from random import choice
 import boto3
@@ -31,10 +31,10 @@ def request_token() -> str:
             InvocationType='RequestResponse'
         )
     except ClientError as err:
-        print_colors(Colors.RED, f'Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
+        print(f'{Style.RED}Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
         raise
     except Exception as err:
-        print_colors(Colors.RED, f'Other error occurred: \n\n{err}')
+        print(f'{Style.RED}Other error occurred: \n\n{err}')
         raise
     else:
         
@@ -58,7 +58,7 @@ def get_valid_user_input(prompt: str, valid_choices: list[str]) -> str:
         if user_input in valid_choices:
             return user_input
         else:
-            print_colors(Colors.YELLOW, '\n\tPlease enter a valid selection.')
+            print(f'{Style.YELLOW}\n\tPlease enter a valid selection.{Style.RESET}')
 
 
 def list_artists(continue_prompt=False) -> None:
@@ -74,9 +74,9 @@ def list_artists(continue_prompt=False) -> None:
     if len(CACHED_ARTIST_LIST) > 0 or IS_CACHE_EMPTY:
         if CACHED_ARTIST_LIST:
             for index, artist in enumerate(CACHED_ARTIST_LIST, start=1):
-                print(f'\n\t[{colorfy(Colors.LIGHT_GREEN, str(index))}] {artist["artist_name"]}')
+                print(f'\n\t[{Style.LIGHT_GREEN}{index}{Style.RESET}] {artist["artist_name"]}')
         else:
-            print_colors(Colors.YELLOW, '\n\tNo artists currently being monitored.')
+            print(f'{Style.YELLOW}\n\tNo artists currently being monitored.{Style.RESET}')
     else: 
         
         # Invoke Lambda to fetch fresh data
@@ -87,10 +87,10 @@ def list_artists(continue_prompt=False) -> None:
                 InvocationType='RequestResponse'
             )    
         except ClientError as err:
-            print_colors(Colors.RED, f'Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
+            print(f'{Style.RED}Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
             raise
         except Exception as err:
-            print_colors(Colors.RED, f'Other error occurred: \n\n{err}')
+            print(f'{Style.RED}Other error occurred: \n\n{err}')
             raise
         else:
 
@@ -107,7 +107,7 @@ def list_artists(continue_prompt=False) -> None:
             
            # Print out list of artists
             elif returned_payload['status_code'] == 204:
-                print_colors(Colors.YELLOW, '\n\tNo artists currently being monitored.')
+                print(f'{Style.YELLOW}\n\tNo artists currently being monitored.{Style.RESET}')
                 
                 # Update cache to be an empty list  
                 CACHED_ARTIST_LIST = []
@@ -118,7 +118,7 @@ def list_artists(continue_prompt=False) -> None:
                 
                 # Print out list of current artists
                 for index, artist in enumerate(list_of_names, start=1):
-                    print(f'\n\t[{colorfy(Colors.LIGHT_GREEN, str(index))}] {artist}')
+                    print(f'\n\t[{Style.LIGHT_GREEN}{index}{Style.RESET}] {artist}')
 
                 # Update cache with current artists list
                 CACHED_ARTIST_LIST = returned_payload['payload']['artists']['current_artists_with_id']
@@ -148,10 +148,10 @@ def fetch_artist_id(artist_name: str, access_token: str) -> tuple[str, str] | No
             Payload=payload.encode()
         )    
     except ClientError as err:
-        print_colors(Colors.RED, f'Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
+        print(f'{Style.RED}Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
         raise
     except Exception as err:
-        print_colors(Colors.RED, f'Other error occurred: \n\n{err}')
+        print(f'{Style.RED}Other error occurred: \n\n{err}')
         raise
     else:
         
@@ -178,7 +178,7 @@ def fetch_artist_id(artist_name: str, access_token: str) -> tuple[str, str] | No
         
         # Serve user the most likely artist they were looking for. Ask for confirmation
         answer = get_valid_user_input(
-            prompt=f'\nIs {colorfy(Colors.LIGHT_GREEN, first_artist_guess["artist_name"])} the artist you were looking for? (yes or no)\n> ',
+            prompt=f'\nIs {Style.LIGHT_GREEN}{first_artist_guess["artist_name"]}{Style.RESET} the artist you were looking for? (yes or no)\n> ',
             valid_choices=(yes_choices + no_choices)
         )
         
@@ -189,7 +189,7 @@ def fetch_artist_id(artist_name: str, access_token: str) -> tuple[str, str] | No
             
             # Print list of the other most likely choices and have them choose
             for index, artist in enumerate(returned_payload['payload']['artistSearchResultsList'], start=1):
-                print(f'\n[{colorfy(Colors.LIGHT_GREEN, str(index))}]')
+                print(f'\n[{Style.LIGHT_GREEN}{index}{Style.RESET}]')
                 print(f'\tArtist: {artist["name"]}')
                 
                 # Format genres into a string
@@ -204,7 +204,7 @@ def fetch_artist_id(artist_name: str, access_token: str) -> tuple[str, str] | No
                     
             # Prompt user for artist choice again
             user_choice = get_valid_user_input(
-                prompt=f'\nWhich artist were you looking for? Select the number. (or enter {colorfy(Colors.YELLOW, "`back`")} to return to search prompt)\n> ',
+                prompt=f'\nWhich artist were you looking for? Select the number. (or enter {Style.YELLOW}`back`{Style.RESET} to return to search prompt)\n> ',
                 valid_choices=[
                     str(option_index) for option_index, artist in enumerate(returned_payload['payload']['artistSearchResultsList'], start=1)
                 ] + go_back_choices
@@ -249,7 +249,7 @@ def add_artist(access_token: str, continue_prompt=False) -> None:
         
         # Find out if artist is already in list. If not, add the artist
         if artist in CACHED_ARTIST_LIST:
-            print(f'\nYou\'re already monitoring {colorfy(Colors.LIGHT_GREEN, artist_name)}!')
+            print(f'\nYou\'re already monitoring {Style.LIGHT_GREEN}{artist_name}{Style.RESET}!')
         else:
             
             # Prep payload
@@ -266,10 +266,10 @@ def add_artist(access_token: str, continue_prompt=False) -> None:
                     Payload=payload.encode()
                 )    
             except ClientError as err:
-                print_colors(Colors.RED, f'Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
+                print(f'{Style.RED}Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
                 raise
             except Exception as err:
-                print_colors(Colors.RED, f'Other error occurred: \n\n{err}')
+                print(f'{Style.RED}Other error occurred: \n\n{err}')
                 raise
             else:
 
@@ -287,7 +287,7 @@ def add_artist(access_token: str, continue_prompt=False) -> None:
 
                     # Update cache with new addition
                     CACHED_ARTIST_LIST.append(artist)
-                    print(f'\n\tYou are now monitoring for {colorfy(Colors.LIGHT_GREEN, artist_name)}\'s new music!')
+                    print(f'\n\tYou are now monitoring for {Style.LIGHT_GREEN}{artist_name}{Style.RESET}\'s new music!')
                     break
                 
     menu_loop_prompt(continue_prompt)
@@ -304,14 +304,14 @@ def remove_artist(continue_prompt=False) -> None:
     # If there are currently no artists to remove, then exit the function
     list_artists()
     if not CACHED_ARTIST_LIST:
-        print_colors(Colors.YELLOW, "\n\tThere are no artists to remove!")
+        print(f"{Style.YELLOW}\n\tThere are no artists to remove!{Style.RESET}")
         menu_loop_prompt(continue_prompt)
         return
 
     # Otherwise, ask them which artist they would like to remove
     go_back_choices = ['b', 'back']
     user_choice = get_valid_user_input(
-        prompt=f'\nWhich artist would you like to remove? Make a selection: (or enter {colorfy(Colors.YELLOW, "`back`")} to return to main menu)\n> ',
+        prompt=f'\nWhich artist would you like to remove? Make a selection: (or enter {Style.YELLOW}`back`{Style.RESET} to return to main menu)\n> ',
         valid_choices=[
             str(choice_index) for choice_index, artist in enumerate(CACHED_ARTIST_LIST, start=1)
         ] + go_back_choices
@@ -337,10 +337,10 @@ def remove_artist(continue_prompt=False) -> None:
                     Payload=payload.encode()
                     )
             except ClientError as err:
-                print_colors(Colors.RED, f'Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
+                print(f'{Style.RED}Client Error Message: \n\t{err.response["Error"]["Code"]}\n\t{err.response["Error"]["Message"]}')
                 raise
             except Exception as err:
-                print_colors(Colors.RED, f'Other error occurred: \n\n{err}')
+                print(f'{Style.RED}Other error occurred: \n\n{err}')
                 raise
             else:
                 
@@ -358,7 +358,7 @@ def remove_artist(continue_prompt=False) -> None:
                     
                     # Update cache by removing artist
                     CACHED_ARTIST_LIST.pop(int(user_choice) - 1)
-                    print(f"\n\tRemoved {colorfy(Colors.LIGHT_GREEN, artist['artist_name'])} from list!")
+                    print(f"\n\tRemoved {Style.LIGHT_GREEN}{artist['artist_name']}{Style.RESET} from list!")
 
     menu_loop_prompt(continue_prompt)
     
@@ -378,7 +378,7 @@ def quit() -> None:
         'auf Wiedersehen',  # German
         'arrivederci',  # Italian
     ]
-    print_colors(Colors.RED, f'\n\tQuitting App! {choice(goodbye_list).title()}!')
+    print(f'{Style.RED}\n\tQuitting App! {choice(goodbye_list).title()}!')
     exit()
 
 
@@ -393,7 +393,7 @@ def menu_loop_prompt(continue_prompt: bool) -> None:
     
     if continue_prompt:
         user_choice = get_valid_user_input(
-            prompt=f"\nPress {colorfy(Colors.LIGHT_GREEN, '[ENTER]')} to go back to main menu... (Or enter {colorfy(Colors.YELLOW, 'quit')} to quit app)\n> ",
+            prompt=f"\nPress {Style.LIGHT_GREEN}[ENTER]{Style.RESET} to go back to main menu... (Or enter {Style.YELLOW}quit{Style.RESET} to quit app)\n> ",
             valid_choices=(quit_choices + go_back_choices)
         )
 

--- a/cli/exceptions/error_handling.py
+++ b/cli/exceptions/error_handling.py
@@ -1,11 +1,11 @@
-from ui.colors import Colors, print_colors, colorfy
+from ui.colors import Style
 
 class FailedToRetrieveToken(Exception):
     """
     Raised when Lambda function returns None for an access token
     """        
     def __str__(self) -> str:
-        return colorfy(Colors.RED, '\n\nFailed to return access_token from "GetAccessTokenHandler"')
+        return f'{Style.RED}\n\nFailed to return access_token from "GetAccessTokenHandler"'
     
 class FailedToRetrieveMonitoredArtists(Exception):
     """
@@ -15,7 +15,7 @@ class FailedToRetrieveMonitoredArtists(Exception):
         self.error_message = error_message
 
     def __str__(self) -> str:
-        return colorfy(Colors.RED, f'\nFailed to retrieve list of artists from DynamoDB table: \n\n{self.error_message}')
+        return f'{Style.RED}\nFailed to retrieve list of artists from DynamoDB table: \n\n{self.error_message}'
     
 class ExceptionDuringLambdaExecution(Exception):
     """
@@ -26,7 +26,7 @@ class ExceptionDuringLambdaExecution(Exception):
         self.lambda_name = lambda_name
 
     def __str__(self) -> str:
-        return colorfy(Colors.RED, f'\nWhile executing {self.lambda_name}, an exception was raised: \n\n{self.error_message}')
+        return f'{Style.RED}\nWhile executing {self.lambda_name}, an exception was raised: \n\n{self.error_message}'
         
 class FailedToRetrieveListOfMatchesWithIDs(Exception):
     """
@@ -36,7 +36,7 @@ class FailedToRetrieveListOfMatchesWithIDs(Exception):
         self.error_message = error_message
 
     def __str__(self) -> str:
-        return colorfy(Colors.RED, f'\nFailed to retrieve list of close matches to user choice from Spotify API: \n\n{self.error_message}')
+        return f'{Style.RED}\nFailed to retrieve list of close matches to user choice from Spotify API: \n\n{self.error_message}'
     
 class FailedToAddArtistToTable(Exception):
     """
@@ -46,7 +46,7 @@ class FailedToAddArtistToTable(Exception):
         self.error_message = error_message
 
     def __str__(self) -> str:
-        return colorfy(Colors.RED, f'\nFailed to add artist to DynamoDB table: \n\n{self.error_message}')
+        return f'{Style.RED}\nFailed to add artist to DynamoDB table: \n\n{self.error_message}'
     
 class FailedToRemoveArtistFromTable(Exception):
     """
@@ -56,4 +56,4 @@ class FailedToRemoveArtistFromTable(Exception):
         self.error_message = error_message
 
     def __str__(self) -> str:
-        return colorfy(Colors.RED, f'\nFailed to remove artist from DynamoDB table: \n\n{self.error_message}')
+        return f'{Style.RED}\nFailed to remove artist from DynamoDB table: \n\n{self.error_message}'

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from ui.colors import Colors, colorfy
+from ui.colors import Style
 from actions.actions import (
     list_artists,
     add_artist,
@@ -13,14 +13,14 @@ import subprocess
 
 def title() -> None:
     subprocess.run(['clear', '-x'])
-    print("""\033[32m
+    print(f"""{Style.GREEN}
     ____             __     __          __
   / ___/____  ____  / /_(_) __(_)____(_) /___  __
   \__ \/ __ \/ __ \/ __/ / /_/ / ___/ / __/ / / /
  ___/ / /_/ / /_/ / /_/ / __/ / /__/ / /_/ /_/ / 
 /____/ .___/\____/\__/_/_/ /_/\___/_/\__/\__, /  
     /_/                                 /____/                                                                                         
-\033[0m""")
+{Style.RESET}""")
 
 
 def main_menu() -> tuple[str, dict]:
@@ -31,32 +31,32 @@ def main_menu() -> tuple[str, dict]:
     title()
     menu_choices = {
         '1': {
-            "choice_name": f"\n\t[{colorfy(Colors.GREEN, '1')}] List Out Current Monitored Artists", 
+            "choice_name": f"\n\t[{Style.GREEN}1{Style.RESET}] List Out Current Monitored Artists", 
             "function": list_artists,
             "token_needed": False,  # Indicates function requires access token to fetch data from Spotify API
             "continue_prompt": True  # If called from main menu, loop back to menu when done
             },
         '2': {
-            "choice_name": f"\n\t[{colorfy(Colors.GREEN, '2')}] Add New Artist to List", 
+            "choice_name": f"\n\t[{Style.GREEN}2{Style.RESET}] Add New Artist to List", 
             "function": add_artist,
             "token_needed": True,
             "continue_prompt": True
             },
         '3': {
-            "choice_name": f"\n\t[{colorfy(Colors.GREEN, '3')}] Remove Artist From List", 
+            "choice_name": f"\n\t[{Style.GREEN}3{Style.RESET}] Remove Artist From List", 
             "function": remove_artist,
             "token_needed": False,
             "continue_prompt": True
             },
         '4': {
-            "choice_name": f"\n\t[{colorfy(Colors.GREEN, '4')}] Quit App", 
+            "choice_name": f"\n\t[{Style.GREEN}4{Style.RESET}] Quit App", 
             "function": quit,
             "token_needed": False,
             "continue_prompt": False
             },
     }
     
-    print(f"\n\t\t {colorfy(Colors.LIGHT_MAGENTA, 'MAIN MENU')}")
+    print(f"\n\t\t {Style.LIGHT_MAGENTA}MAIN MENU{Style.RESET}")
     print("\t\t===========")
 
     # List out menu choices

--- a/cli/ui/colors.py
+++ b/cli/ui/colors.py
@@ -1,9 +1,9 @@
-class Colors: 
+class Style:
     """
     A class that contains all the colors that can be used in the terminal.
     """ 
       
-    RESET_ALL        = '\033[0m'  # Indicates the end of the color sequence
+    RESET            = '\033[0m'  # Indicates the end of the color sequence
 
     BOLD             = "\033[1m"
     DIM              = "\033[2m"
@@ -36,26 +36,4 @@ class Colors:
     LIGHT_MAGENTA    = "\033[95m"
     LIGHT_CYAN       = "\033[96m"
     WHITE            = "\033[97m"
-
-
-def print_colors(color, string: str) -> None:
-    """
-    Stylizes a whole print function.
-    
-    :param color: The color to stylize the text with.
-    :param string: The string to stylize.
-    :return: None. Prints the stylized string.
-    """
-    
-    print(color + string + Colors.RESET_ALL)
-
-def colorfy(color, string: str) -> str:
-    """
-    Stylizes a string.
-    
-    :param color: The color to stylize the text with.
-    :param string: The string to stylize.
-    :return: The stylized string.
-    """
-    return color + string + Colors.RESET_ALL
 


### PR DESCRIPTION
## Summary:

In a bid to enhance readability and streamline my terminal output styling, this pull request involves modifications to the `colors.py` file. The `Colors` class has been renamed to `Style`, and both the `colorfy` and `print_colors` functions have been removed. This refactoring not only simplifies our code but also presents a cleaner approach to applying terminal styling. 

## Changes:

1. **Renamed Class**: The Colors class has been renamed to Style for a more generic and intuitive naming convention.
2. **Removed Helper Functions**:
   - The `colorfy` function, which was previously used to wrap text with desired styles, has been removed.
   - The `print_colors` function, aimed at printing stylized text to the terminal directly, has also been removed.
3. **Code Refactoring**: All references to `colorfy` and `print_colors` across the codebase have been removed or refactored. Instead of using helper functions, now styles can be directly applied, making the code more concise and readable. For example, `print(f'\n\t[{Style.LIGHT_GREEN}{index}{Style.RESET}] {artist["artist_name"]}')` is now favored over the previous `print(f'\n\t[{colorfy(Colors.LIGHT_GREEN, str(index))}] {artist["artist_name"]}')`.
4. **Updated Imports**: Any import statements in Python files that were importing colorfy and print_colors have been cleaned up to reflect their removal.

